### PR TITLE
Fix README comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ client.recipients = '+421900123456'
 
 result = client.send_message("Hello World!")
 if result.success:
-    # message was sended without any error
+    # message was sent without any error
     print(result.data) 
     delivery_status = client.get_message_status(result.data)
     if delivery_status.success:


### PR DESCRIPTION
## Summary
- fix typo in README example comment
- ensure README ends with a newline

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'zeep')*

------
https://chatgpt.com/codex/tasks/task_e_685c44e783988324b493c41e618a959f