### PR TITLE
Fix grammar in recipients setter docstring

### DIFF
--- a/smsfarm/core.py
+++ b/smsfarm/core.py
@@ -121,7 +121,8 @@ class Client(object):
         """
         Setter for property recipients.
 
-        Does not any validation if given telephone number is valid or not.
+        This method performs no validation to check whether the given
+        telephone number is valid.
 
         Args:
             recipients:


### PR DESCRIPTION
## Summary
- fix grammatical error in `recipients` setter docstring

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'zeep')*

------
https://chatgpt.com/codex/tasks/task_e_685c465c4888832490127dd64ff9988b